### PR TITLE
Fixed duplicate creation bug of a playlist when page refreshing

### DIFF
--- a/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.sass
+++ b/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.sass
@@ -215,8 +215,9 @@ img[src='']
   margin: 15px 0px 5px 0px
   color: $text
 
-.search
+.ui.search
   padding-right: 18px
+  padding-left: 10px
   .ui.icon.input
     color: $text !important 
     width: 500px !important

--- a/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.ts
+++ b/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.ts
@@ -95,7 +95,7 @@ export class CreateEditPlaylistComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this._unsubscribe$))
       .subscribe({
         next: (data) => {
-          this.playlist = data;
+          this._router.navigateByUrl(`/playlists/edit/${data.id}`);
         }
       });
   }

--- a/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.html
+++ b/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.html
@@ -16,7 +16,7 @@
                   <div class="hover-content">
                     <img id="image" src="{{tempIconURL}}">
                     <i class="edit outline icon"></i>
-                    <input pattern=".*(.jpg$|.png$|.jpeg$)" type="file" (change)="loadIcon($event)" name="iconURL" 
+                    <input pattern="{{pattern}}" type="file" (change)="loadIcon($event)" name="iconURL" 
                       [ngModel] #iconURL="ngModel" accept=".jpeg,.png,.jpg">
                     <div *ngIf="iconURL.invalid && (iconURL.dirty || iconURL.touched)" class="ui error message">
                       <div *ngIf="iconURL.errors?.pattern">

--- a/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.html
+++ b/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.html
@@ -16,7 +16,7 @@
                   <div class="hover-content">
                     <img id="image" src="{{tempIconURL}}">
                     <i class="edit outline icon"></i>
-                    <input pattern="\S*.jpg$|\S*.png$|\S*.jpeg$" type="file" (change)="loadIcon($event)" name="iconURL" 
+                    <input pattern=".*(.jpg$|.png$|.jpeg$)" type="file" (change)="loadIcon($event)" name="iconURL" 
                       [ngModel] #iconURL="ngModel" accept=".jpeg,.png,.jpg">
                     <div *ngIf="iconURL.invalid && (iconURL.dirty || iconURL.touched)" class="ui error message">
                       <div *ngIf="iconURL.errors?.pattern">

--- a/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.ts
+++ b/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.ts
@@ -10,6 +10,7 @@ import { EditedPlaylist } from 'src/app/models/playlist/editedPlaylist';
   styleUrls: ['./edit-playlist-modal.component.sass']
 })
 export class EditPlaylistModalComponent implements OnInit {
+  readonly pattern = '.*(.jpg$|.png$|.jpeg$)';
   file: File;
   public selectControlValues: AccessType[] = [AccessType.secret, AccessType.collaborative, AccessType.default];
   public tempIconURL: string;
@@ -36,8 +37,7 @@ export class EditPlaylistModalComponent implements OnInit {
   loadIcon = (event: Event) => {
     const [file] = Array.from((event.target as HTMLInputElement).files as FileList);
 
-    const pattern = /.*(.jpg$|.png$|.jpeg$)/i;
-    if (pattern.test(file.name)) {
+    if (RegExp(this.pattern).test(file.name)) {
       this.file = file;
       const reader = new FileReader();
 

--- a/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.ts
+++ b/frontend/src/app/modules/main/create-edit-playlist/edit-playlist-modal/edit-playlist-modal.component.ts
@@ -36,7 +36,7 @@ export class EditPlaylistModalComponent implements OnInit {
   loadIcon = (event: Event) => {
     const [file] = Array.from((event.target as HTMLInputElement).files as FileList);
 
-    const pattern = /\S*.jpg$|\S*.png$|\S*.jpeg$/i;
+    const pattern = /.*(.jpg$|.png$|.jpeg$)/i;
     if (pattern.test(file.name)) {
       this.file = file;
       const reader = new FileReader();

--- a/frontend/src/app/modules/main/main-menu/main-menu.component.html
+++ b/frontend/src/app/modules/main/main-menu/main-menu.component.html
@@ -46,7 +46,7 @@
         {{ playlist }}
       </li>
     </ul>
-    <button class="ui btn-full button create-playlist" (click)="createPlaylist()">
+    <button class="ui btn-full button create-playlist" routerLink="playlists/create" (click)="createPlaylist()">
       Create Playlist
     </button>
   </div>


### PR DESCRIPTION
1. Fixed bug with creating duplicate playlist when refreshing the page
2. Corrected pattern term of image input in 'edit-playlist-modal.component'
3. Repaired route of button 'Create playlist' on the left side menu (routerLink="playlists/create")
4. Added "padding-left: 10px" to the search container in 'create-edit-playlist.component'