### PR TITLE
Create/edit playlist showing w/o reloading page

### DIFF
--- a/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.ts
+++ b/frontend/src/app/modules/main/create-edit-playlist/create-edit-playlist/create-edit-playlist.component.ts
@@ -14,6 +14,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { EditedPlaylist } from 'src/app/models/playlist/editedPlaylist';
 import { User } from 'src/app/models/user/user';
 import { AuthService } from 'src/app/services/auth/auth.service';
+import { CreatePlaylistService } from 'src/app/modules/shared/playlist/create-playlist/create-playlist.service';
 
 @Component({
   selector: 'app-create-edit-playlist',
@@ -39,7 +40,8 @@ export class CreateEditPlaylistComponent implements OnInit, OnDestroy {
     private _songService: SongsService,
     private _router: Router,
     private _activatedRoute: ActivatedRoute,
-    private _authService: AuthService
+    private _authService: AuthService,
+    private _createdPlaylistService: CreatePlaylistService
   ) {
     this._authService.getAuthStateObservable()
       .pipe(filter((state) => !!state))
@@ -106,6 +108,7 @@ export class CreateEditPlaylistComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (data) => {
           this._router.navigateByUrl(`/playlists/edit/${data.id}`);
+          this._createdPlaylistService.addPlaylist(data);
         }
       });
   }
@@ -142,6 +145,7 @@ export class CreateEditPlaylistComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (data) => {
           this.playlist = data;
+          this._createdPlaylistService.addPlaylist(data);
         }
       });
   };

--- a/frontend/src/app/modules/main/main-menu/main-menu.component.ts
+++ b/frontend/src/app/modules/main/main-menu/main-menu.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { PlaylistName } from 'src/app/models/playlist/playlist-name';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { PlaylistsService } from 'src/app/services/playlists/playlist.service';
+import { CreatePlaylistService } from '../../shared/playlist/create-playlist/create-playlist.service';
 
 @Component({
   selector: 'app-main-menu',
@@ -18,12 +19,22 @@ export class MainMenuComponent implements OnDestroy, OnInit {
 
   constructor(
     private _playlistsService: PlaylistsService,
-    private _authService: AuthService
+    private _authService: AuthService,
+    private _createdPlaylistService: CreatePlaylistService
   ) {
   }
 
   public ngOnInit() {
     this.getUserCreatedPlaylists();
+    this._createdPlaylistService.playlistChanged$.subscribe((playlist) => {
+      const playlistIndex = this.playlists.findIndex((pl) => pl.id === playlist?.id);
+      if (playlistIndex === -1) {
+        this.playlists.push(playlist!);
+      }
+      else {
+        this.playlists[playlistIndex] = playlist!;
+      }
+    });
   }
 
   public ngOnDestroy() {

--- a/frontend/src/app/modules/shared/playlist/create-playlist/create-playlist.service.ts
+++ b/frontend/src/app/modules/shared/playlist/create-playlist/create-playlist.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Playlist } from 'src/app/models/playlist';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CreatePlaylistService {
+  lastPlaylist: Playlist = {
+    id: 0,
+    createdAt: new Date(),
+    name: '',
+    description: '',
+    iconURL: ''
+  };
+  private _playlistSubject$ = new BehaviorSubject<Playlist | null>(this.lastPlaylist);
+  playlistChanged$ = this._playlistSubject$.asObservable();
+
+  addPlaylist(playlist: Playlist) {
+    this.lastPlaylist = playlist;
+    this._playlistSubject$.next(playlist);
+  }
+}


### PR DESCRIPTION
When "Create playlist" button clicked - shows this playlist without page reloading. If playlist name changed - also changes name of playlist in left-side menu w/o page reloading.